### PR TITLE
自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -39,7 +39,6 @@ $(function () {
       return html;
     };
   }
-
   $('#new_message').on('submit', function (e) {
     e.preventDefault()
     var formData = new FormData(this);

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -73,11 +73,17 @@ $(function () {
       data: { id: last_message_id }
     })
       .done(function (messages) {
+        if (messages.length !== 0) {
         var insertHTML = '';
         $.each(messages, function (i, message) {
           insertHTML += buildHTML(message)
         });
         $('.messages').append(insertHTML);
+        $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight });
+        $("#new_message")[0].reset();
+        $(".form__submit").prop("disabled", false);
+        }
+      })
   };
   setInterval(reloadMessages, 7000);
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -66,5 +66,11 @@ $(function () {
   })
   var reloadMessages = function () {
     last_message_id = $('.message:last').data("message-id");
+    $.ajax({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: { id: last_message_id }
+    })
   };
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -64,5 +64,7 @@ $(function () {
       alert("メッセージ送信に失敗しました");
     });
   })
+  var reloadMessages = function () {
     last_message_id = $('.message:last').data("message-id");
+  };
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -88,5 +88,7 @@ $(function () {
         alert("自動更新に失敗しました");
       });
   };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
   setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -84,6 +84,9 @@ $(function () {
         $(".form__submit").prop("disabled", false);
         }
       })
+      .fail(function () {
+        alert("自動更新に失敗しました");
+      });
   };
   setInterval(reloadMessages, 7000);
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -44,6 +44,7 @@ $(function () {
     e.preventDefault()
     var formData = new FormData(this);
     var url = $(this).attr('action')
+    last_message_id = $('.message:last').data("message-id");
     $.ajax({
       url: url,
       type: "POST",
@@ -63,4 +64,5 @@ $(function () {
       alert("メッセージ送信に失敗しました");
     });
   })
+    last_message_id = $('.message:last').data("message-id");
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -79,4 +79,5 @@ $(function () {
         });
         $('.messages').append(insertHTML);
   };
+  setInterval(reloadMessages, 7000);
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -72,5 +72,11 @@ $(function () {
       dataType: 'json',
       data: { id: last_message_id }
     })
+      .done(function (messages) {
+        var insertHTML = '';
+        $.each(messages, function (i, message) {
+          insertHTML += buildHTML(message)
+        });
+        $('.messages').append(insertHTML);
   };
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,4 @@
+class Api::MessagesController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,4 +1,7 @@
 class Api::MessagesController < ApplicationController
   def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
   end
 end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message: {id: message.id}}}
   .message__info
     %p.message__info__talker
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.content @message.content
 json.image @message.image_url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,6 @@ Rails.application.routes.draw do
 root to: "groups#index"
 resources :users, only: [:index,:edit, :update]
 resources :groups, only: [:new, :create, :edit, :update] do
-  resources :messages, only: [:index, :create]
+resources :messages, only: [:index, :create]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,9 @@ root to: "groups#index"
 resources :users, only: [:index,:edit, :update]
 resources :groups, only: [:new, :create, :edit, :update] do
 resources :messages, only: [:index, :create]
+
+      namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,9 +4,9 @@ Rails.application.routes.draw do
 root to: "groups#index"
 resources :users, only: [:index,:edit, :update]
 resources :groups, only: [:new, :create, :edit, :update] do
-resources :messages, only: [:index, :create]
+  resources :messages, only: [:index, :create]
 
-      namespace :api do
+    namespace :api do
       resources :messages, only: :index, defaults: { format: 'json' }
     end
   end


### PR DESCRIPTION
# What
自動更新機能の実装をする
ブラウザを更新しなくても同じグループのユーザー同士のメッセージを見ることができるようにする為
1. メッセージのidをカスタムデータ属性として追加
- 表示されているメッセージのidが確認できるようにする
2. 最新の投稿を取得できるように設定
- apiディレクトリを作成し、それぞれ使用するコントローラー作成
- indexアクションを設定、ルーティングの追加
3. 投稿内容のレスポンスできるように設定
- json形式でレスポンスするためのファイルを作成・記述
- jBuilderの設定
- 最新のメッセージidを取得できるように設定
4. ７秒ごとに自動更新するように設定
5. 機能のブラッシュアップ
- メッセージ取得後、メッセージが自動スクロールするように設定
- グループ一覧画面以外で自走更新しないように設定

自動更新機能テスト動画
https://gyazo.com/a177114848acff0b8620409155591276
https://gyazo.com/c83f787410417c5ad250286163fdbd7c

# Why
実装することで、より快適かつスピーディーにメッセージのやり取りができる為